### PR TITLE
Update NameCheap WHMCS Domains Module for WHMCS 5/6

### DIFF
--- a/namecheap.php
+++ b/namecheap.php
@@ -2,10 +2,10 @@
 // ****************************************************************************
 // *                                                                          *
 // * NameCheap.com WHMCS Registrar Module                                     *
-// * Version 1.2.8
+// * Version 1.2.8                                                            *
 // * http://code.google.com/p/namecheap/                                      *
 // *                                                                          *
-// * Copyright 2008-2013 NameCheap.com                                        *
+// * Copyright 2008-2015 NameCheap.com                                        *
 // *                                                                          *
 // * Licensed under the Apache License, Version 2.0 (the "License");          *
 // * you may not use this file except in compliance with the License.         *
@@ -23,15 +23,14 @@
 // *                                                                          *
 // * To install, create a folder named namecheap under                        *
 // * modules/registrar under your whmcs root directory and place              *
-// * namecheap.php, namecheapapi.php, namecheapsync.php,                      *
-// * additionaldomainfields.php, logo.gif into it.                            *
+// * namecheap.php, namecheapapi.php, additionaldomainfields.php              *
+// * logo.gif into it                                                         *
 // * Then in WHMCS admin menu, go to registrar module settings and select     *
 // * Namecheap, and configure. You should enter your api key in               *
 // * the password field and api username in username field.                   *
 // *                                                                          *
 // ****************************************************************************
 // * Changes:
-// *
 // * April, 17, 2014 (1.2.8)
 // * - Added ability to enable WhoisGuard with transfers
 // * - Added active and transfer domain syncing module functions according to WHMCS Domain Cron Synchronisation flow
@@ -131,15 +130,30 @@
 function namecheap_getConfigArray()
 {
     $configarray = array(
-        'Username' => array('Type' => "text", 'Size' => "20", 'Description' => "Enter your username here."),
-        'Password' => array('Type' => "text", 'Size' => "20", 'Description' => "Enter your API key here. To get your api key, go to Manage Profile section in Namecheap.com, then click API access link on the left hand side. C/p the key here. DON'T include your password."),
-        //'AddFreePositiveSSL' => array('Type' => "yesno", 'Description' => 'Add free PositiveSSL for the domains purchased'),
-        'PromotionCode' => array('Type' => "text", 'Size' => "20", 'Description' => "Enter your promotional (coupon) code."),
-        'SandboxUsername' => array('Type' => "text", 'Size' => "20", 'Description' => "Enter your sandbox username here. (This will be used only if you set the test mode on.)"),
-        'SandboxPassword' => array('Type' => "text", 'Size' => "20", 'Description' => "Enter your sandbox API key here. (This will be used only if you set the test mode on.)"),
-        'TestMode' => array('Type' => "yesno"),
-        //'SyncNextDueDate' => array('Type' => "yesno", 'Description' => "Tick this box if you want the expiry date sync script to update the expiry and next due dates (cron must be configured)"),
-        'DebugMode' => array('Type' => "yesno"),
+        'Username' => array('Type' => "text", 'Size' => "20", 'Description' => "Enter your username here.",),
+        'Password' => array(
+            'Type' => "text",
+            'Size' => "20",
+            'Description' => "Enter your API key here. "
+                . "To get your api key, go to Manage Profile section in Namecheap.com,"
+                . " then click API access link on the left hand side. C/p the key here. DON'T include your password.",
+        ),
+        'PromotionCode' => array(
+            'Type' => "text",
+            'Size' => "20",
+            'Description' => "Enter your promotional (coupon) code.",
+        ),
+        'SandboxUsername' => array(
+            'Type' => "text",
+            'Size' => "20",
+            'Description' => "Enter your sandbox username here. (This will be used only if you set the test mode on.)",
+        ),
+        'SandboxPassword' => array(
+            'Type' => "text",
+            'Size' => "20",
+            'Description' => "Enter your sandbox API key here. (This will be used only if you set the test mode on.)",
+        ),
+        'TestMode' => array('Type' => "yesno",),
     );
     return $configarray;
 }
@@ -149,33 +163,32 @@ function namecheap_GetNameservers($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     // do not get nameservers for domains that not registered
-    $r = mysql_query('SELECT * from tbldomains WHERE id='.(int)$params['domainid']);
-    if (!mysql_num_rows($r)){
-        return;
-    }    
-    $row = mysql_fetch_assoc($r);    
-    if (!in_array($row['status'],array(/*'Pending','Pending Transfer',*/'Active','Expired',/*'Cancelled','Fraud'*/))){
-        return;
+    if (!in_array(
+        get_query_val('tbldomains', 'status', array('id' => $params['domainid'])),
+        array('Active', 'Expired'))
+    ) {
+        return array('error' => 'Unable to obtain Nameservers for an unregistered domain');
     }
-    
-    
+    $response = '';
+    $result = $request_params = $values = array();
+
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
-    $sld = $oIDNA->getEncodedSld();    
-    
+    $sld = $oIDNA->getEncodedSld();
+
     try
     {
         $request_params = array(
             'SLD' => $sld,
             'TLD' => $tld
         );
-        $api = new NamecheapRegistrarApi($username, $password, $testmode,$debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.dns.getList", $request_params);
         $result = $api->parseResponse($response);
 
@@ -191,28 +204,34 @@ function namecheap_GetNameservers($params)
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'GetNameservers', array('command' => "namecheap.domains.dns.getList") + $request_params, $response, $result, array());
-        }
+        logModuleCall(
+            'namecheap',
+            'GetNameservers',
+            array('command' => "namecheap.domains.dns.getList") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
 
 function namecheap_SaveNameservers($params)
 {
-    
+
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
     $sld = $oIDNA->getEncodedSld();
-    
+    $response = '';
+    $result = $request_params = $values = array();
+
     $defaultNs = true;
     $defaultNsServers = array("dns1.registrar-servers.com", "dns2.registrar-servers.com", "dns3.registrar-servers.com", "dns4.registrar-servers.com", "dns5.registrar-servers.com");
 
@@ -223,30 +242,35 @@ function namecheap_SaveNameservers($params)
             $defaultNs = false;
         }
     }
-    
+
     try
     {
         $request_params = array(
             'SLD' => $sld,
             'TLD' => $tld
         );
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
-        
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
+
         if (false===$defaultNs){
             $request_params['Nameservers'] = implode(',', $nameservers);
             $response = $api->request("namecheap.domains.dns.setCustom", $request_params);
         }else{
             $response = $api->request("namecheap.domains.dns.setDefault", $request_params);
         }
-        
-        
+
+
         $result = $api->parseResponse($response);
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'SetNameservers', array('command' => "namecheap.domains.dns.setCustom") + $request_params, $response, $result, array());
-        }
+        logModuleCall(
+            'namecheap',
+            'SetNameservers',
+            array('command' => "namecheap.domains.dns.setCustom") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -256,21 +280,23 @@ function namecheap_GetRegistrarLock($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
     $sld = $oIDNA->getEncodedSld();
+
+    $response = '';
+    $result = $request_params = $values = array();
 
     try
     {
         $request_params = array(
             'DomainName' => $sld . '.' . $tld
         );
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.getRegistrarLock", $request_params);
         $result = $api->parseResponse($response);
 
@@ -279,9 +305,14 @@ function namecheap_GetRegistrarLock($params)
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'GetRegistrarLock', array('command' => "namecheap.domains.getRegistrarLock") + $request_params, $response, $result, array());
-        }
+        logModuleCall(
+            'namecheap',
+            'GetRegistrarLock',
+            array('command' => "namecheap.domains.getRegistrarLock") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -291,14 +322,16 @@ function namecheap_SaveRegistrarLock($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
-    $sld = $oIDNA->getEncodedSld();    
+    $sld = $oIDNA->getEncodedSld();
+
+    $response = '';
+    $result = $request_params = $values = array();
 
     try
     {
@@ -306,21 +339,26 @@ function namecheap_SaveRegistrarLock($params)
             'DomainName' => $sld . '.' . $tld,
             'LockAction' => ("locked" == $params['lockenabled']) ? "lock" : "unlock"
         );
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.setRegistrarLock", $request_params);
         $result = $api->parseResponse($response);
     }
     catch (Exception $e) {
-        $rl_unable_domains = array("ca", "cm", "co.uk", "org.uk", "me.uk", "de", "eu", "ws");
+        $rl_unable_domains = array("ca", "cm", "co.uk", "org.uk", "me.uk", "de", "eu", "ws", "uk");
 
         $msg = $e->getMessage();
         $values['error'] = "An error occurred: " . $msg;
         if ("[3031510] Failed to get Registrar Lock Status" == $msg && in_array(strtolower($tld), $rl_unable_domains)) {
             $values['error'] = "Registrar lock is not applicable for <strong>" . $tld . "</strong> domains.";
         }
-        if (!$debugmode){
-            logModuleCall('namecheap', 'SaveRegistrarLock', array('command' => "namecheap.domains.setRegistrarLock") + $request_params, $response, $result, array());   
-        }
+        logModuleCall(
+            'namecheap',
+            'SaveRegistrarLock',
+            array('command' => "namecheap.domains.setRegistrarLock") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -330,21 +368,22 @@ function namecheap_GetEmailForwarding($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
     $sld = $oIDNA->getEncodedSld();
 
+    $response = '';
+    $result = $request_params = $values = array();
     try
     {
         $request_params = array(
             'DomainName' => $sld . '.' . $tld
         );
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.dns.getEmailForwarding", $request_params);
         $result = $api->parseResponse($response);
 
@@ -363,9 +402,14 @@ function namecheap_GetEmailForwarding($params)
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'GetEmailForwarding', array('command' => "namecheap.domains.dns.getEmailForwarding") + $request_params, $response, $result, array()); 
-        }
+        logModuleCall(
+            'namecheap',
+            'GetEmailForwarding',
+            array('command' => "namecheap.domains.dns.getEmailForwarding") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -375,14 +419,15 @@ function namecheap_SaveEmailForwarding($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
     $sld = $oIDNA->getEncodedSld();
+    $response = '';
+    $result = $request_params = $values = array();
 
     try
     {
@@ -395,15 +440,20 @@ function namecheap_SaveEmailForwarding($params)
                 $request_params['ForwardTo' . ($k + 1)] = $params['forwardto'][$k];
             }
         }
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.dns.setEmailForwarding", $request_params);
         $result = $api->parseResponse($response);
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'SaveEmailForwarding', array('command' => "namecheap.domains.dns.setEmailForwarding") + $request_params, $response, $result, array());   
-        }
+        logModuleCall(
+            'namecheap',
+            'SaveEmailForwarding',
+            array('command' => "namecheap.domains.dns.setEmailForwarding") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -413,22 +463,22 @@ function namecheap_GetDNS($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
     $sld = $oIDNA->getEncodedSld();
-
+    $response = '';
+    $result = $request_params = $values = array();
     try
     {
         $request_params = array(
             'SLD' => $sld,
             'TLD' => $tld
         );
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.dns.getHosts", $request_params);
         $result = $api->parseResponse($response);
 
@@ -436,7 +486,6 @@ function namecheap_GetDNS($params)
         if (!isset($host[0])) {
             $host = array($host);
         }
-        $values = array();
         foreach ($host as $v) {
             $values[] = array(
                 'hostname' => $v['@attributes']['Name'],
@@ -447,9 +496,14 @@ function namecheap_GetDNS($params)
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'GetDNS', array('command' => "namecheap.domains.dns.getHosts") + $request_params, $response, $result, array());   
-        }
+        logModuleCall(
+            'namecheap',
+            'GetDNS',
+            array('command' => "namecheap.domains.dns.getHosts") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -459,22 +513,22 @@ function namecheap_SaveDNS($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
-    $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
-    $sld = $oIDNA->getEncodedSld();    
 
+    $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
+    $sld = $oIDNA->getEncodedSld();
+    $response = '';
+    $result = $request_params = $values = array();
     try
     {
         $request_params = array(
             'SLD' => $sld,
             'TLD' => $tld
         );
-        
+
         foreach ($params['dnsrecords'] as $k => $v) {
             if (!empty($v['hostname']) && !empty($v['type']) && !empty($v['address'])) {
                 $request_params['HostName' . ($k + 1)]   = $v['hostname'];
@@ -488,60 +542,61 @@ function namecheap_SaveDNS($params)
                 }
             }
         }
-        
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.dns.setHosts", $request_params);
         $result = $api->parseResponse($response);
 
         if (isset($result['DomainDNSSetHostsResult']['Warnings']['Warning'])) {
             $message = "Saving DNS warning<br />"
-                     . "-----------------------------------------------------------------------------------------<br />"
-                     . $result['DomainDNSSetHostsResult']['Warnings']['Warning']['@value'] . "<br />"
-                     . "-----------------------------------------------------------------------------------------<br />"
-                     . "Domain: " . $tld . "." . $sld . "<br />"
-                     . "<pre>" .  print_r($params['dnsrecords']) . "</pre>";
-            sendadminnotification("system", "WHMCS Namecheap Domain Registrar Module", $message);
+                . "-----------------------------------------------------------------------------------------<br />"
+                . $result['DomainDNSSetHostsResult']['Warnings']['Warning']['@value'] . "<br />"
+                . "-----------------------------------------------------------------------------------------<br />"
+                . "Domain: " . $tld . "." . $sld . "<br />"
+                . "<pre>" .  print_r($params['dnsrecords']) . "</pre>";
+            sendAdminNotification("system", "WHMCS Namecheap Domain Registrar Module", $message);
         }
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'SaveDNS', array('command' => "namecheap.domains.dns.setHosts") + $request_params, $response, $result, array());   
-        }
+        logModuleCall(
+            'namecheap',
+            'SaveDNS',
+            array('command' => "namecheap.domains.dns.setHosts") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
 
 function namecheap_RegisterDomain($params)
 {
-    
+
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
-    $sld = $oIDNA->getEncodedSld();    
-    
-    $nameservers = array($params['ns1'], $params['ns2'], $params['ns3'], $params['ns4'],$params['ns5']);
+    $sld = $oIDNA->getEncodedSld();
+    $response = '';
+    $result = $request_params = $values = array();
+    $nameservers = array($params['ns1'], $params['ns2'], $params['ns3'], $params['ns4'], $params['ns5']);
     foreach ($nameservers as $k => $v) {
         if (!$v) { unset($nameservers[$k]); }
     }
     try
     {
-        
+
         if('ca'==strtolower($tld)){
-            // change state province for US and CA countries            
-            if(!empty(NamecheapRegistrarApi::$_caStateProvince[$params['admincountry']][str_replace(' ', '', $params['adminstate'] )])){
-                $params['adminstate'] = NamecheapRegistrarApi::$_caStateProvince[$params['admincountry']][str_replace(' ', '', $params['adminstate'] )];
-            }
             $params['adminpostcode'] =str_replace(' ','',$params['adminpostcode']);
             // change zip code
-            if('CA'==$params['admincountry']){                
+            if('CA'==$params['admincountry']){
                 if(' ' != $params['adminpostcode'][3]){
                     $params['adminpostcode'] = substr($params['adminpostcode'], 0, 3) . ' ' . substr($params['adminpostcode'], 3);
                 }
@@ -552,8 +607,8 @@ function namecheap_RegisterDomain($params)
                 }
             }
         }
-        
-        
+
+
         // Client Details
         $registrant = array(
             'RegistrantFirstName'        => $params['firstname'],
@@ -565,11 +620,11 @@ function namecheap_RegisterDomain($params)
             'RegistrantStateProvince'    => $params['state'],
             'RegistrantPostalCode'       => $params['postcode'],
             'RegistrantCountry'          => $params['country'],
-            'RegistrantPhone'            => $params['phonenumber'],
-            'RegistrantEmailAddress'     => $params['email'],            
+            'RegistrantPhone'            => $params['fullphonenumber'],
+            'RegistrantEmailAddress'     => $params['email'],
         );
-        
-        
+
+
         // Billing/Admin/Tech Contact Details
         $registrantAdmin = array(
             'FirstName'        => $params['adminfirstname'],
@@ -581,19 +636,19 @@ function namecheap_RegisterDomain($params)
             'StateProvince'    => $params['adminstate'],
             'PostalCode'       => $params['adminpostcode'],
             'Country'          => $params['admincountry'],
-            'Phone'            => $params['adminphonenumber'],
-            'EmailAddress'     => $params['adminemail'],            
+            'Phone'            => $params['adminfullphonenumber'],
+            'EmailAddress'     => $params['adminemail'],
         );
-        
-        
+
+
         $aux = $tech = $admin = array();
         foreach ($registrantAdmin as $k => $v) {
             $admin["Admin" . $k] = $v;
             $tech["Tech" . $k] = $v;
             $aux["AuxBilling" . $k] = $v;
         }
-        
-        
+
+
         $request_params = array(
             'DomainName'  => $sld . '.' . $tld,
             'Years'       => $params['regperiod'],
@@ -608,14 +663,11 @@ function namecheap_RegisterDomain($params)
             $request_params['PromotionCode'] = $params['PromotionCode'];
         }
         // whois guard
-        $wg_ex = array("bz", "ca", "cn", "co.uk", "de", "eu", "in", "me.uk", "mobi", "nu", "org.uk", "us", "ws");
+        $wg_ex = array("bz", "ca", "cn", "co.uk", "de", "eu", "in", "me.uk", "mobi", "nu", "org.uk", "us", "ws", "uk");
         if ($params['idprotection'] && !in_array(strtolower($tld), $wg_ex)) {
             $request_params['AddFreeWhoisguard'] = "yes";
             $request_params['WGEnabled']         = "yes";
         }
-        //if ($params['AddFreePositiveSSL']) {
-        //    $request_params['AddFreePositiveSSL'] = "yes";
-        //}
         // extended attributes for some TLDs
         if ('eu' == strtolower($tld)) { // for .eu domains
             $request_params['EUAgreeWhoisPolicy']  = "YES";
@@ -658,12 +710,12 @@ function namecheap_RegisterDomain($params)
                     break;
             }
         } elseif ('ca' == strtolower($tld)) {
-            
+
             $request_params['CIRAWhoisDisplay']     = ("on" == $params['additionalfields']['WHOIS Opt-out']) ? "Private" : "Full";
             $request_params['CIRAAgreementVersion'] = "2.0";
             $request_params['CIRAAgreementValue']   = ("on" == $params['additionalfields']['CIRA Agreement']) ? "Y" : "";
             $request_params['CIRALanguage']         = "en";
-            
+
             if(!empty($params['additionalfields']['jobTitle'])){
                 $jobTitle = $params['additionalfields']['jobTitle'];
             }else if(!empty($params['additionalfields']['Job Title'])){
@@ -671,13 +723,13 @@ function namecheap_RegisterDomain($params)
             }else{
                 $jobTitle = 'Director';
             }
-            
+
             $request_params['RegistrantJobTitle'] = $jobTitle;
             $request_params['AdminJobTitle'] = $jobTitle;
             $request_params['TechJobTitle'] = $jobTitle;
             $request_params['AuxBillingJobTitle'] = $jobTitle;
 
-            
+
             /**
              * missing from WHMCS:
              * "INB" - Indian Band
@@ -735,7 +787,12 @@ function namecheap_RegisterDomain($params)
                     break;
             }
 
-        } elseif ('co.uk' == strtolower($tld) || 'org.uk' == strtolower($tld) || 'me.uk' == strtolower($tld)) {
+        } elseif (
+            'co.uk' == strtolower($tld)
+            || 'org.uk' == strtolower($tld)
+            || 'me.uk' == strtolower($tld)
+            || 'uk' == strtolower($tld)
+        ) {
             $key = strtoupper(str_replace('.', '', $tld));
 
             $request_params[$key . 'CompanyID']     = $params['additionalfields']['Company ID Number'];
@@ -777,6 +834,24 @@ function namecheap_RegisterDomain($params)
                 case 'Other foreign organizations':
                     $request_params[$key . 'LegalType'] = "FOTHER";
                     break;
+                case "UK Industrial/Provident Registered Company":
+                    $request_params[$key . 'LegalType'] = "IP";
+                    break;
+                case "UK School":
+                    $request_params[$key . 'LegalType'] = "SCH";
+                    break;
+                case "UK Government Body":
+                    $request_params[$key . 'LegalType'] = "GOV";
+                    break;
+                case "UK Corporation by Royal Charter":
+                    $request_params[$key . 'LegalType'] = "CRC";
+                    break;
+                case "UK Statutory Body":
+                    $request_params[$key . 'LegalType'] = "STAT";
+                    break;
+                case "Non-UK Individual":
+                    $request_params[$key . 'LegalType'] = "FIND";
+                    break;
                 case 'Individual':
                 default:
                     $request_params[$key . 'LegalType'] = "IND";
@@ -795,16 +870,16 @@ function namecheap_RegisterDomain($params)
         } elseif('com.sg' == strtolower($tld)){
             $request_params['COMSGRCBID'] = $params['additionalfields']['RCB Singapore ID'];
         } elseif ('com.au' == strtolower($tld) || 'net.au' == strtolower($tld) || 'org.au' == strtolower($tld)){
-            
-            $key_prefix = strtoupper(str_replace('.','',$tld));            
-            $request_params[$key_prefix.'RegistrantId'] = $params['additionalfields']['Registrant ID'];            
-            
+
+            $key_prefix = strtoupper(str_replace('.','',$tld));
+            $request_params[$key_prefix.'RegistrantId'] = $params['additionalfields']['Registrant ID'];
+
             if('Business Registration Number' == $params['additionalfields']['Registrant ID Type']){
                 $params['additionalfields']['Registrant ID Type'] = 'RBN';
             }
             $request_params[$key_prefix.'RegistrantIdType'] = $params['additionalfields']['Registrant ID Type'];
-            
-            
+
+
             if(!empty($params['additionalfields']['jobTitle'])){
                 $jobTitle = $params['additionalfields']['jobTitle'];
             }else if(!empty($params['additionalfields']['Job Title'])){
@@ -812,21 +887,21 @@ function namecheap_RegisterDomain($params)
             }else{
                 $jobTitle = 'Director';
             }
-            
-            
+
+
             $request_params['RegistrantJobTitle'] = $jobTitle;
             $request_params['AdminJobTitle'] = $jobTitle;
             $request_params['TechJobTitle'] = $jobTitle;
             $request_params['AuxBillingJobTitle'] = $jobTitle;
-            
-            
-        } elseif('es' == strtolower($tld)||'com.es' == strtolower($tld)||'nom.es' == strtolower($tld)||'org.es' ==  strtolower($tld)){            
-            
+
+
+        } elseif('es' == strtolower($tld)||'com.es' == strtolower($tld)||'nom.es' == strtolower($tld)||'org.es' ==  strtolower($tld)){
+
             $key_prefix = strtoupper(str_replace('.','',$tld));
-            $request_params[$key_prefix.'RegistrantId'] = $params['additionalfields']['ID Form Number'];            
-            
+            $request_params[$key_prefix.'RegistrantId'] = $params['additionalfields']['ID Form Number'];
+
         } elseif ('fr' == strtolower($tld)){
-            
+
             if(!empty($params['additionalfields']['Legal Type'])){
                 $request_params['FRLegalType'] = $params['additionalfields']['Legal Type'];
             }
@@ -860,30 +935,35 @@ function namecheap_RegisterDomain($params)
             if(!empty($params['additionalfields']['Journal Page'])){
                 $request_params['FRRegistrantJoPage'] = $params['additionalfields']['Journal Page'];
             }
-            
+
         }
-        
-        
-            $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
-            $response = $api->request("namecheap.domains.create", $request_params);
-            $result = $api->parseResponse($response);
-        
+
+
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
+        $response = $api->request("namecheap.domains.create", $request_params);
+        $result = $api->parseResponse($response);
+
         if (isset($result['DomainCreateResult']['warnings']['Warning'])) {
             $message = "Registering Domain warning<br />"
-                     . "-----------------------------------------------------------------------------------------<br />"
-                     . $result['DomainCreateResult']['warnings']['Warning']['@value'] . "<br />"
-                     . "-----------------------------------------------------------------------------------------<br />"
-                     . "Domain: " . $tld . "." . $sld . "<br />"
-                     . "Nameservers: " . implode(',', $nameservers);
+                . "-----------------------------------------------------------------------------------------<br />"
+                . $result['DomainCreateResult']['warnings']['Warning']['@value'] . "<br />"
+                . "-----------------------------------------------------------------------------------------<br />"
+                . "Domain: " . $tld . "." . $sld . "<br />"
+                . "Nameservers: " . implode(',', $nameservers);
 
-            sendadminnotification("system", "WHMCS Namecheap Domain Registrar Module", $message);
+            sendAdminNotification("system", "WHMCS Namecheap Domain Registrar Module", $message);
         }
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'RegisterDomain', array('command' => "namecheap.domains.create") + $request_params, $response, $result, array());   
-        }
+        logModuleCall(
+            'namecheap',
+            'RegisterDomain',
+            array('command' => "namecheap.domains.create") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -893,15 +973,15 @@ function namecheap_TransferDomain($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
     $sld = $oIDNA->getEncodedSld();
-    
+    $response = '';
+    $result = $request_params = $values = array();
     try
     {
         $request_params = array(
@@ -912,22 +992,27 @@ function namecheap_TransferDomain($params)
         if (!empty($params['PromotionCode'])) {
             $request_params['PromotionCode'] = $params['PromotionCode'];
         }
-        
+
         $wg_ex = array("bz", "ca", "cn", "co.uk", "de", "eu", "in", "me.uk", "mobi", "nu", "org.uk", "us", "ws");
         if ($params['idprotection'] && !in_array(strtolower($tld), $wg_ex)) {
             $request_params['AddFreeWhoisguard'] = "yes";
             $request_params['WGEnabled']         = "yes";
         }
-        
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.transfer.create", $request_params);
         $result = $api->parseResponse($response);
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'TransferDomain', array('command' => "namecheap.domains.transfer.create") + $request_params, $response, $result, array());   
-        }
+        logModuleCall(
+            'namecheap',
+            'TransferDomain',
+            array('command' => "namecheap.domains.transfer.create") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -937,15 +1022,15 @@ function namecheap_RenewDomain($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
     $sld = $oIDNA->getEncodedSld();
-
+    $response = '';
+    $result = $request_params = $values = array();
     $exCode = 0;
     try
     {
@@ -956,7 +1041,7 @@ function namecheap_RenewDomain($params)
         if (!empty($params['PromotionCode'])) {
             $request_params['PromotionCode'] = $params['PromotionCode'];
         }
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.renew", $request_params);
         $result = $api->parseResponse($response);
         $values['status'] = "Domain Renewed";
@@ -964,6 +1049,14 @@ function namecheap_RenewDomain($params)
     catch (Exception $e) {
         $exCode = $e->getCode();
         $values['error'] = "An error occurred: " . $e->getMessage();
+        logModuleCall(
+            'namecheap',
+            'RenewDomain',
+            array('command' => "namecheap.domains.renew") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     if ($exCode != 2020166) {
         return $values;
@@ -974,7 +1067,7 @@ function namecheap_RenewDomain($params)
         unset($values['error']);
         unset($request_params['Years']);
 
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.reactivate", $request_params);
         $result = $api->parseResponse($response);
         $values['status'] = "Domain Reactivated";
@@ -982,9 +1075,14 @@ function namecheap_RenewDomain($params)
     catch (Exception $e)
     {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'RenewDomain', array('command' => "namecheap.domains.reactivate") + $request_params, $response, $result, array());   
-        }
+        logModuleCall(
+            'namecheap',
+            'ReactivateDomain',
+            array('command' => "namecheap.domains.reactivate") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -994,21 +1092,21 @@ function namecheap_GetContactDetails($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
 
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
-    $sld = $oIDNA->getEncodedSld();    
-    
+    $sld = $oIDNA->getEncodedSld();
+    $response = '';
+    $result = $request_params = $values = array();
     try
     {
         $request_params = array(
             'DomainName' => $sld . '.' . $tld
         );
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.getContacts", $request_params);
         $result = $api->parseResponse($response);
 
@@ -1035,9 +1133,14 @@ function namecheap_GetContactDetails($params)
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'GetContactDetails', array('command' => "namecheap.domains.getContacts") + $request_params, $response, $result, array());   
-        }
+        logModuleCall(
+            'namecheap',
+            'GetContactDetails',
+            array('command' => "namecheap.domains.getContacts") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -1047,15 +1150,15 @@ function namecheap_SaveContactDetails($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
     $sld = $oIDNA->getEncodedSld();
-
+    $response = '';
+    $result = $request_params = $values = array();
     try
     {
         $request_params = array(
@@ -1079,50 +1182,29 @@ function namecheap_SaveContactDetails($params)
                 $request_params[$k . 'EmailAddress']     = $v['Email'];
             }
         }
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.setContacts", $request_params);
         $result = $api->parseResponse($response);
 
         if (isset($result['DomainSetContactResult']['Warnings']['Warning'])) {
             $message = "Saving Contact Details warning<br />"
-                     . "-----------------------------------------------------------------------------------------<br />"
-                     . $result['DomainSetContactResult']['Warnings']['Warning']['@value'] . "<br /"
-                     . "-----------------------------------------------------------------------------------------<br />"
-                     . "Domain: " . $sld . "." . $tld;
-            sendadminnotification("system", "WHMCS Namecheap Domain Registrar Module", $message);
+                . "-----------------------------------------------------------------------------------------<br />"
+                . $result['DomainSetContactResult']['Warnings']['Warning']['@value'] . "<br /"
+                . "-----------------------------------------------------------------------------------------<br />"
+                . "Domain: " . $sld . "." . $tld;
+            sendAdminNotification("system", "WHMCS Namecheap Domain Registrar Module", $message);
         }
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'SaveContactDetails', array('command' => "namecheap.domains.setContacts") + $request_params, $response, $result, array());   
-        }
-    }
-    return $values;
-}
-
-function namecheap_GetEPPCode($params)
-{
-    // Assign all the global params required for the call to namecheap api
-    $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
-    $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
-    $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
-    $tld = $params['tld'];
-    $sld = $params['sld'];
-    
-    /*$oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
-    $sld = $oIDNA->getEncodedSld();    */
-
-    // Put your code to request the EPP code here - if the API returns it, pass back as below - otherwise return no value and it will assume code is emailed
-    //$values['eppcode'] = $eppcode;
-
-    // If error, return the error message in the value below
-    if (defined('CLIENTAREA') && CLIENTAREA == true) {
-        $values['error'] = "This function is not available. Please contact support to obtain EPP Code for this domain";
-    } else {
-        $values['error'] = "This function is not available via Namecheap API. "
-            . "You can obtain EPP Code through your Namecheap Domain Management page or by sending a request to support@namecheap.com";
+        logModuleCall(
+            'namecheap',
+            'SaveContactDetails',
+            array('command' => "namecheap.domains.setContacts") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -1132,15 +1214,15 @@ function namecheap_RegisterNameserver($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
     $sld = $oIDNA->getEncodedSld();
-
+    $response = '';
+    $result = $request_params = $values = array();
     try
     {
         $request_params = array(
@@ -1150,15 +1232,20 @@ function namecheap_RegisterNameserver($params)
             'IP' => $params['ipaddress']
         );
 
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.ns.create", $request_params);
         $result = $api->parseResponse($response);
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'RegisterNameserver', array('command' => "namecheap.domains.ns.create") + $request_params, $response, $result, array());   
-        }
+        logModuleCall(
+            'namecheap',
+            'RegisterNameserver',
+            array('command' => "namecheap.domains.ns.create") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -1168,15 +1255,15 @@ function namecheap_ModifyNameserver($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
     $sld = $oIDNA->getEncodedSld();
-
+    $response = '';
+    $result = $request_params = $values = array();
     try
     {
         $request_params = array(
@@ -1187,15 +1274,20 @@ function namecheap_ModifyNameserver($params)
             'OldIP' => $params['currentipaddress']
         );
 
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.ns.update", $request_params);
         $result = $api->parseResponse($response);
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'ModifyNameserver', array('command' => "namecheap.domains.ns.update") + $request_params, $response, $result, array());   
-        }
+        logModuleCall(
+            'namecheap',
+            'ModifyNameserver',
+            array('command' => "namecheap.domains.ns.update") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
@@ -1205,15 +1297,15 @@ function namecheap_DeleteNameserver($params)
     require_once dirname(__FILE__) . "/namecheapapi.php";
 
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
 
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
-    $sld = $oIDNA->getEncodedSld();    
-    
+    $sld = $oIDNA->getEncodedSld();
+    $response = '';
+    $result = $request_params = $values = array();
     try
     {
         $request_params = array(
@@ -1222,161 +1314,117 @@ function namecheap_DeleteNameserver($params)
             'Nameserver' => $params['nameserver']
         );
 
-        $api = new NamecheapRegistrarApi($username, $password, $testmode, $debugmode);
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
         $response = $api->request("namecheap.domains.ns.delete", $request_params);
         $result = $api->parseResponse($response);
     }
     catch (Exception $e) {
         $values['error'] = "An error occurred: " . $e->getMessage();
-        if (!$debugmode){
-            logModuleCall('namecheap', 'DeleteNameserver', array('command' => "namecheap.domains.ns.delete") + $request_params, $response, $result, array());   
-        }
+        logModuleCall(
+            'namecheap',
+            'DeleteNameserver',
+            array('command' => "namecheap.domains.ns.delete") + $request_params,
+            $response,
+            $result,
+            array($password)
+        );
     }
     return $values;
 }
 
 
 function namecheap_Sync($params){
-    
-    
+
     require_once dirname(__FILE__) . "/namecheapapi.php";
-    
+
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
-    
-    static $cache;
-    $values = array();
-    
-    if(empty($cache)){
-        
-        // load domains
-        $domains = array();
-        try {
-            $page = 1;
-            $pageSize = 100;
-            do
-            {
-                $request_params = array(
-                    'ListType' => "ALL",
-                    'Page'     => $page,
-                    'PageSize' => $pageSize,
-                    'SortBy'   => "NAME"
-                );
-                if (!empty($params['PromotionCode'])) {
-                    $request_params['PromotionCode'] = $params['PromotionCode'];
-                }
-                $api = new NamecheapRegistrarApi($username, $password, $testmode);
-                $response = $api->request("namecheap.domains.getList", $request_params);
-                $result = $api->parseResponse($response);
-                $domains += $api->parseResultSyncHelper($result['DomainGetListResult']['Domain'], "Name");
 
-                $totalItems = $result['Paging']['TotalItems'];
-                $pageSize = $result['Paging']['PageSize'];
-            } while (($pageSize * $page++) <= $totalItems);
-        } catch (Exception $e) {
-            $values['error'] = $e->getMessage();            
-            return $values;
-        }
-        
-        // and put the result into the cache
-        $cache['domains'] = $domains;
-        
-    }
-    
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
     $sld = $oIDNA->getEncodedSld();
-    
-    
-    $domain = $cache['domains']["$sld.$tld"];
-    if(empty($domain)){
+
+    $values = array();
+
+    try {
+        $request_params = array(
+            'ListType' => "ALL",
+            'Page'     => 1,
+            'PageSize' => 10,
+            'SortBy'   => "NAME",
+            'SearchTerm' => "$sld.$tld",
+        );
+        if (!empty($params['PromotionCode'])) {
+            $request_params['PromotionCode'] = $params['PromotionCode'];
+        }
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
+        $response = $api->request("namecheap.domains.getList", $request_params);
+        $result = $api->parseResponse($response);
+        $domains = $api->parseResultSyncHelper($result['DomainGetListResult']['Domain'], "Name");
+    } catch (Exception $e) {
+        $values['error'] = $e->getMessage();
+        return $values;
+    }
+
+    if (empty($domains["$sld.$tld"])) {
         $values['error'] = 'Domain not found';
         return $values;
     }
-    
-    // $values['active'] = true;
-    
-    $values['expired'] =  'true' === strtolower($domain['IsExpired']);    
-    $values['expirydate'] = date("Y-m-d", strtotime($domain['Expires']));
 
-    
+    $values['expired'] =  'true' === strtolower($domains["$sld.$tld"]['IsExpired']);
+    $values['expirydate'] = date("Y-m-d", strtotime($domains["$sld.$tld"]['Expires']));
+
     return $values;
-    
+
 }
 
 
 function namecheap_TransferSync($params) {
-    
+
     require_once dirname(__FILE__) . "/namecheapapi.php";
-    
+
     $testmode = (bool)$params['TestMode'];
-    $debugmode =(bool)$params['DebugMode'];
     $username = $testmode ? $params['SandboxUsername'] : $params['Username'];
     $password = $testmode ? $params['SandboxPassword'] : $params['Password'];
     $tld = $params['tld'];
     $sld = $params['sld'];
-    
-    
-    static $cache;
-    $values = array();
-    
-    
-    if(empty($cache)){
-        
-        $domains = array();
-        try {
-            $page = 1;
-            $pageSize = 100;
-            do
-            {
-                $request_params = array(
-                    //'ListType' => "COMPLETED",
-                    'ListType' => "ALL",
-                    'Page'     => $page,
-                    'PageSize' => $pageSize,
-                    'SortBy'   => "DOMAINNAME"
-                );
-                if (!empty($params['PromotionCode'])) {
-                    $request_params['PromotionCode'] = $params['PromotionCode'];
-                }
-                $api = new NamecheapRegistrarApi($username, $password, $testmode);
-                $response = $api->request("namecheap.domains.transfer.getList", $request_params);
-                $result = $api->parseResponse($response);
-                $domains += $api->parseResultSyncHelper($result['TransferGetListResult']['Transfer'], "DomainName");
-                $totalItems = $result['Paging']['TotalItems'];
-                $pageSize = $result['Paging']['PageSize'];
-            } while (($pageSize * $page++) <= $totalItems);
-        } catch (Exception $e) {
-            $values['error'] = $e->getMessage();
-            return $values;
-        }
-        
-        $cache['domains'] = $domains;
-        
-        
-    }
-    
-    
+
     $oIDNA = new NamecheapRegistrarIDNA($sld, $tld);
     $sld = $oIDNA->getEncodedSld();
-    
-    $domain = $cache['domains']["$sld.$tld"];
-    
-    if(empty($domain)){
+
+    try {
+        $request_params = array(
+            'ListType' => "ALL",
+            'Page'     => 1,
+            'PageSize' => 10,
+            'SortBy'   => "DOMAINNAME",
+            'SearchTerm' => "$sld.$tld",
+        );
+        if (!empty($params['PromotionCode'])) {
+            $request_params['PromotionCode'] = $params['PromotionCode'];
+        }
+        $api = new NamecheapRegistrarApi($username, $password, $testmode);
+        $response = $api->request("namecheap.domains.transfer.getList", $request_params);
+        $result = $api->parseResponse($response);
+        $domains = $api->parseResultSyncHelper($result['TransferGetListResult']['Transfer'], "DomainName");
+    } catch (Exception $e) {
+        $values['error'] = $e->getMessage();
+        return $values;
+    }
+
+    if (empty($domains["$sld.$tld"])){
         $values['error'] = 'Domain not found';
         return $values;
     }
-    
-    if('completed' ===  strtolower($domain['Status'])){
+
+    if ('completed' ===  strtolower($domains["$sld.$tld"]['Status'])) {
         $values['completed'] = true;
     }else{
-        $values['error'] = $domain['StatusDescription'];
+        $values['error'] = $domains["$sld.$tld"]['StatusDescription'];
     }
-    
+
     return $values;
-    
+
 }

--- a/namecheap.php
+++ b/namecheap.php
@@ -2,7 +2,7 @@
 // ****************************************************************************
 // *                                                                          *
 // * NameCheap.com WHMCS Registrar Module                                     *
-// * Version 1.2.8                                                            *
+// * Version 1.2.9                                                            *
 // * http://code.google.com/p/namecheap/                                      *
 // *                                                                          *
 // * Copyright 2008-2015 NameCheap.com                                        *
@@ -31,6 +31,14 @@
 // *                                                                          *
 // ****************************************************************************
 // * Changes:
+// * March, 26, 2015 (1.2.9)
+// * - Removed debug mode
+// * - Removed transforming CA and US states as this is already done in WHMCS
+// * - Updated the phone number field used for domain registrations as WHMCS formats this correctly already
+// * - Whenever logModuleCall is used in the main file, ensure that password is passed to be obscured
+// * - Updated sync to search for the specific domain over listing all domains
+// * - Correct some docblocks in the namecheapapi file.
+// * - Add support for uk domains
 // * April, 17, 2014 (1.2.8)
 // * - Added ability to enable WhoisGuard with transfers
 // * - Added active and transfer domain syncing module functions according to WHMCS Domain Cron Synchronisation flow

--- a/namecheapapi.php
+++ b/namecheapapi.php
@@ -1,391 +1,312 @@
 <?php
 
-
 /**
  * NamecheapRegistrarApi
  */
 if(!class_exists('NamecheapRegistrarApi')){
-class NamecheapRegistrarApi
-{
-    public static $url = "https://api.namecheap.com/xml.response";
-    public static $testUrl = "https://api.sandbox.namecheap.com/xml.response";
-
-    private static $_phoneCountryCodes = array(
-        1, 7, 20, 27, 30, 31, 32, 33, 34, 36, 39, 40, 41, 43, 44, 45, 46, 47, 48, 49, 51, 52, 54, 55, 56, 57, 58, 60,
-        61, 62, 63, 64, 65, 66, 81, 82, 84, 86, 90, 91, 92, 93, 94, 95, 98, 212, 213, 216, 220, 221, 222, 224, 225, 226,
-        227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 248, 249,
-        250, 251, 252, 253, 254, 255, 256, 257, 258, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 290, 291, 297,
-        298, 299, 340, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 370, 371, 372, 373, 374, 375, 376, 377, 378,
-        380, 381, 382, 385, 386, 387, 389, 420, 421, 423, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 590, 591,
-        592, 593, 594, 595, 596, 597, 598, 599, 618, 670, 672, 673, 674, 675, 676, 677, 678, 679, 680, 681, 682, 683,
-        684, 686, 687, 688, 689, 690, 691, 692, 850, 852, 853, 855, 856, 872, 880, 886, 960, 961, 962, 963, 965, 966,
-        967, 968, 970, 971, 972, 973, 974, 975, 976, 977, 992, 993, 994, 995, 996, 998
-    );
-    
-    public static $_caStateProvince = array(
-        'US' => array(
-            "ArmedForcesAmericas(exceptCanada)"=>"AA",
-            "ArmedForcesAfrica"=>"AE",
-            "ArmedForcesCanada"=>"AE",
-            "ArmedForcesEurope"=>"AE",
-            "ArmedForcesMiddleEast"=>"AE",
-            "Alaska"=>"AK",
-            "Alabama"=>"AL",
-            "ArmedForcesPacific"=>"AP",
-            "AmericanSamoa"=>"AS",
-            "Arizona"=>"AZ",
-            "Arkansas"=>"AR",
-            "California"=>"CA",
-            "Colorado"=>"CO",
-            "Connecticut"=>"CT",
-            "Delaware"=>"DE",
-            "DistrictofColumbia"=>"DC",
-            "FederatedStatesofMicronesia"=>"FM",
-            "Florida"=>"FL",
-            "Georgia"=>"GA",
-            "Guam"=>"GU",
-            "Hawaii"=>"HI",
-            "Idaho"=>"ID",
-            "Illinois"=>"IL",
-            "Indiana"=>"IN",
-            "Iowa"=>"IA",
-            "Kansas"=>"KS",
-            "Kentucky"=>"KY",
-            "Louisiana"=>"LA",
-            "Maine"=>"ME",
-            "MarshallIslands"=>"MH",
-            "Maryland"=>"MD",
-            "Massachusetts"=>"MA",
-            "Michigan"=>"MI",
-            "Minnesota"=>"MN",
-            "Mississippi"=>"MS",
-            "Missouri"=>"MO",
-            "Montana"=>"MT",
-            "Nebraska"=>"NE",
-            "Nevada"=>"NV",
-            "NewHampshire"=>"NH",
-            "NewJersey"=>"NJ",
-            "NewMexico"=>"NM",
-            "NewYork"=>"NY",
-            "NorthCarolina"=>"NC",
-            "NorthDakota"=>"ND",
-            "NorthernMarianaIslands"=>"MP",
-            "Ohio"=>"OH",
-            "Oklahoma"=>"OK",
-            "Oregon"=>"OR",
-            "Palau"=>"PW",
-            "Pennsylvania"=>"PA",
-            "PuertoRico"=>"PR",
-            "RhodeIsland"=>"RI",
-            "SouthCarolina"=>"SC",
-            "SouthDakota"=>"SD",
-            "Tennessee"=>"TN",
-            "Texas"=>"TX",
-            "Utah"=>"UT",
-            "Vermont"=>"VT",
-            "VirginIslands"=>"VI",
-            "Virginia"=>"VA",
-            "Washington"=>"WA",
-            "WestVirginia"=>"WV",
-            "Wisconsin"=>"WI",
-            "Wyoming"=>"WY",
-        ),
-        'CA' => array(
-            "Alberta" => "AB",
-            "BritishColumbia" => "BC",
-            "Manitoba" => "MB",
-            "NewBrunswick" => "NB",
-            "NewfoundlandandLabrador" => "NL",
-            "NorthwestTerritories" => "NT",
-            "NovaScotia" => "NS",
-            "Nunavut" => "NU",
-            "Ontario" => "ON",
-            "PrinceEdwardIsland" => "PE",
-            "Quebec" => "QC",
-            "Saskatchewan" => "SK",
-            "Yukon" => "YK"
-        ),
-    );
-    
-    private $_apiUser;
-    private $_apiKey;
-
-    private $_testMode = true;
-    private $_debugMode = false;
-
-    private $_requestUrl;
-    private $_requestParams;
-    private $_response;
-
-    public function  __construct($apiUser, $apiKey, $testMode = true, $debugMode = false)
+    class NamecheapRegistrarApi
     {
-        $this->_apiUser = $apiUser;
-        $this->_apiKey  = $apiKey;
+        public static $url = "https://api.namecheap.com/xml.response";
+        public static $testUrl = "https://api.sandbox.namecheap.com/xml.response";
 
-        $this->setTestMode($testMode);
-        $this->setDebugMode($debugMode);
-    }
+        private static $_phoneCountryCodes = array(
+            1, 7, 20, 27, 30, 31, 32, 33, 34, 36, 39, 40, 41, 43, 44, 45, 46, 47, 48, 49, 51, 52, 54, 55, 56, 57, 58, 60,
+            61, 62, 63, 64, 65, 66, 81, 82, 84, 86, 90, 91, 92, 93, 94, 95, 98, 212, 213, 216, 220, 221, 222, 224, 225, 226,
+            227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 248, 249,
+            250, 251, 252, 253, 254, 255, 256, 257, 258, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 290, 291, 297,
+            298, 299, 340, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 370, 371, 372, 373, 374, 375, 376, 377, 378,
+            380, 381, 382, 385, 386, 387, 389, 420, 421, 423, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 590, 591,
+            592, 593, 594, 595, 596, 597, 598, 599, 618, 670, 672, 673, 674, 675, 676, 677, 678, 679, 680, 681, 682, 683,
+            684, 686, 687, 688, 689, 690, 691, 692, 850, 852, 853, 855, 856, 872, 880, 886, 960, 961, 962, 963, 965, 966,
+            967, 968, 970, 971, 972, 973, 974, 975, 976, 977, 992, 993, 994, 995, 996, 998
+        );
 
-    /**
-     * getLastUrl
-     * @return string
-     */
-    public function getLastUrl() {
-        return $this->_requestUrl;
-    }
+        private $_apiUser;
+        private $_apiKey;
 
-    /**
-     * getLastParams
-     * @return string
-     */
-    public function getLastParams() {
-        return $this->_requestParams;
-    }
+        private $_testMode = true;
 
-    /**
-     * getLastResponse
-     * @return string
-     */
-    public function getLastResponse() {
-        return $this->_response;
-    }
+        private $_requestUrl;
+        private $_requestParams;
+        private $_response;
 
-    /**
-     * parseResponse
-     * @param string $response
-     * @return array
-     */
-    public function parseResponse($response)
-    {
-        if (false === ($xml = simplexml_load_string($response))) {
-            throw new NamecheapRegistrarApiException("Unable to parse response");
-        }
-        $result = $this->_xml2Array($xml);
-        if ("ERROR" == $result['@attributes']['Status']) {
-            $errors = isset($result['Errors']['Error'][0]) ? $result['Errors']['Error'] : array($result['Errors']['Error']);
-
-            
-            $msg = '';
-            //$err = $errors[count($errors) - 1];
-            
-            foreach ($errors as $err){
-                $err_msg = sprintf("[%s] %s", $err['@attributes']['Number'], $err['@value']) ;
-                $msg .= $err_msg;
-            }
-            
-            //throw new NamecheapRegistrarApiException($err_msg, $err['@attributes']['Number']);
-            throw new NamecheapRegistrarApiException($msg, $err['@attributes']['Number']);
-        }
-        return $result['CommandResponse'];
-    }
-
-    /**
-     * request
-     * @param string $command
-     * @param array $params
-     * @return string
-     */
-    public function request($command, array $params)
-    {
-        $this->_requestUrl = $this->_getApiUrl($command, $params);
-        $this->_requestParams = $this->_getApiParams($command, $params);
-
-        $curl_error = false;
-        if (extension_loaded("curl") && ($ch = curl_init()) !== false)
+        public function  __construct($apiUser, $apiKey, $testMode = true)
         {
-            curl_setopt($ch, CURLOPT_URL, $this->_requestUrl);
-            curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1);
-            // we set peer verification of namecheap server to false - else the process will fail
-            // if the host server doesn't have an accurate ca bundle.
-            // can turn this on, when you place an up to date ca bundle at your host server.
-            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-            curl_setopt($ch, CURLOPT_HEADER, 0);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
-            $this->_response = curl_exec($ch);
-            $curl_error = curl_error($ch);
+            $this->_apiUser = $apiUser;
+            $this->_apiKey  = $apiKey;
 
-            curl_close($ch);
+            $this->setTestMode($testMode);
         }
-        
-        // if we didn't get a response from curl, or curl had encountered an error, do it through fsockopen.
-        if (!$this->_response || $curl_error) {
-            $this->_response = @file_get_contents($this->_requestUrl);
-        }
-        
-        
-        // debug mode
-        if ($this->_debugMode){
-            if(function_exists('logModuleCall')){
-                $logRequestParams = $this->_requestParams;
-                $logRequestParams['ApiKey'] = '***';
-                logModuleCall('namecheap', $command, $logRequestParams, $this->_response, null, array());
-            }
-        }
-        //
-        
-        if (!$this->_response) {
-            throw new NamecheapRegistrarApiException($curl_error ? $curl_error : "Unable to request data from " . $this->_requestUrl);
-        }
-        
-        return $this->_response;
-    }
 
-    /**
-     * setTestMode
-     * @param boolean $flag
-     */
-    public function setTestMode($flag)
-    {
-        $this->_testMode = (bool)$flag;
-    }
-    
-    public function setDebugMode($flag)
-    {
-        $this->_debugMode = (bool)$flag;
-    }
-
-    // private methods
-
-    /**
-     * formatPhone
-     * @param string $phone
-     * @return string
-     */
-    private function _formatPhone($phone)
-    {
         /**
-         * Namecheap API phone format requirement is +NNN.NNNNNNNNNN
+         * getLastUrl
+         * @return string
          */
-
-        // strip all non-digit characters
-        $phone = preg_replace('/[^\d]/', '', $phone);
-
-        // check country code
-        $phone_code = "";
-        foreach (self::$_phoneCountryCodes as $v) {
-            if (preg_match("/^$v\d+$/", $phone)) {
-                $phone_code = $v;
-                break;
-            }
-        }
-        if (!$phone_code) {
-            throw new Exception("Invalid phone number or phone country code: $phone");
-        }
-        // add '+' and dot to result phone number
-        $phone = preg_replace("/^$phone_code/", "+{$phone_code}.", $phone);
-        return $phone;
-    }
-    
-
-    /**
-     * _getApiParams
-     * @param string $command
-     * @param array $params
-     * @return array
-     */
-    private function _getApiParams($command, array $params)
-    {
-        
-        $params['Command'] = $command;
-        $params['ApiUser'] = $this->_apiUser;
-        $params['ApiKey']  = $this->_apiKey;
-
-        if (!array_key_exists('UserName', $params) || !strlen($params['UserName'])) {
-            $params['UserName'] = $params['ApiUser'];
-        }
-        if (!array_key_exists('ClientIp', $params)) {
-            $params['ClientIp'] = $this->_getClientIp();
-        }
-        
-        
-        // format phone/fax fields
-        foreach ($params as $k => &$v) {
-            if (preg_match('/(Phone|Fax)/i', $k)) {
-                $v = trim($v);
-                if(!empty($v)){
-                    $v = $this->_formatPhone($v);
-                }
-            }
+        public function getLastUrl() {
+            return $this->_requestUrl;
         }
 
-        // force EPPCode to be base64 encoded
-        if (array_key_exists('EPPCode', $params)) {
-            $params['EPPCode'] = htmlspecialchars_decode($params['EPPCode'], ENT_QUOTES);            
-            $params['EPPCode'] = "base64:" . base64_encode($params['EPPCode']);
+        /**
+         * getLastParams
+         * @return string
+         */
+        public function getLastParams() {
+            return $this->_requestParams;
         }
-        return $params;
-    }
-    
-    
-    public function parseResultSyncHelper($items, $domainNameKey = "DomainName")
-    {
-        $result = array();
-        foreach ($items as $t)
+
+        /**
+         * getLastResponse
+         * @return string
+         */
+        public function getLastResponse() {
+            return $this->_response;
+        }
+
+        /**
+         * Parse the response into an array.
+         *
+         * @throws NamecheapRegistrarApiException
+         *
+         * @param string $response
+         *
+         * @return array
+         */
+        public function parseResponse($response)
         {
-            $attr = $t['@attributes'];
-            $result[strtolower($attr[$domainNameKey])] = $attr;
-        }
-        return $result;
-    }
-            
-    
-    /**
-     * _getApiUrl
-     * @param string $command
-     * @param array $params
-     * @return string
-     */
-    private function _getApiUrl($command, array $params)
-    {
-        return ($this->_testMode ? self::$testUrl : self::$url) . '?' . http_build_query($this->_getApiParams($command, $params),'','&');
-    }
+            if (false === ($xml = simplexml_load_string($response))) {
+                throw new NamecheapRegistrarApiException("Unable to parse response");
+            }
+            $result = $this->_xml2Array($xml);
+            if ("ERROR" == $result['@attributes']['Status']) {
+                $errors = isset($result['Errors']['Error'][0]) ? $result['Errors']['Error'] : array($result['Errors']['Error']);
 
-    /**
-     * _getClientIp
-     * @return string
-     */
-    private function _getClientIp()
-    {
-        $clientip = $_SERVER['REMOTE_ADDR'];
-        return $clientip ? $clientip : "10.11.12.13";
-    }
 
-    /**
-     * _xml2Array
-     * @param string $xml
-     * @return array
-     */
-    private function _xml2Array($xml)
-    {
-        if (!($xml instanceof SimpleXMLElement)) {
-            throw new NamecheapRegistrarApiException("Not a SimpleXMLElement object");
-        }
-        $result = array();
-        foreach ($xml->attributes() as $attrName => $attr) {
-            $result['@attributes'][$attrName] = (string)$attr;
-        }
-        foreach ($xml->children() as $childName => $child) {
-            if (array_key_exists($childName, $result)) {
-                if (!is_array($result[$childName]) || !isset($result[$childName][1])) {
-                    $result[$childName] = array($result[$childName]);
+                $msg = '';
+                //$err = $errors[count($errors) - 1];
+
+                foreach ($errors as $err){
+                    $err_msg = sprintf("[%s] %s", $err['@attributes']['Number'], $err['@value']) ;
+                    $msg .= $err_msg;
                 }
-                $result[$childName][] = $this->_xml2Array($child);
+
+                //throw new NamecheapRegistrarApiException($err_msg, $err['@attributes']['Number']);
+                throw new NamecheapRegistrarApiException($msg, $err['@attributes']['Number']);
+            }
+            return $result['CommandResponse'];
+        }
+
+        /**
+         * Send the request to the API
+         *
+         * @throws NamecheapRegistrarApiException
+         *
+         * @param string $command
+         * @param array $params
+         *
+         * @return string
+         */
+        public function request($command, array $params)
+        {
+            $this->_requestUrl = $this->_getApiUrl($command, $params);
+            $this->_requestParams = $this->_getApiParams($command, $params);
+
+            $curl_error = false;
+            if (extension_loaded("curl") && ($ch = curl_init()) !== false)
+            {
+                curl_setopt($ch, CURLOPT_URL, $this->_requestUrl);
+                curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1);
+                // we set peer verification of namecheap server to false - else the process will fail
+                // if the host server doesn't have an accurate ca bundle.
+                // can turn this on, when you place an up to date ca bundle at your host server.
+                curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+                curl_setopt($ch, CURLOPT_HEADER, 0);
+                curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+                curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+                $this->_response = curl_exec($ch);
+                $curl_error = curl_error($ch);
+
+                curl_close($ch);
+            }
+
+            // if we didn't get a response from curl, or curl had encountered an error, do it through fsockopen.
+            if (!$this->_response || $curl_error) {
+                $this->_response = @file_get_contents($this->_requestUrl);
+            }
+
+
+            if (function_exists('logModuleCall'))
+            {
+                $logRequestParams = $this->_requestParams;
+                logModuleCall(
+                    'namecheap',
+                    $command,
+                    $logRequestParams,
+                    $this->_response . "\n" . $curl_error,
+                    $this->_response . "\n" . $curl_error,
+                    array($logRequestParams['ApiKey'])
+                );
+            }
+
+            if (!$this->_response) {
+                throw new NamecheapRegistrarApiException($curl_error ? $curl_error : "Unable to request data from " . $this->_requestUrl);
+            }
+
+            return $this->_response;
+        }
+
+        /**
+         * setTestMode
+         * @param boolean $flag
+         */
+        public function setTestMode($flag)
+        {
+            $this->_testMode = (bool)$flag;
+        }
+
+        // private methods
+
+        /**
+         * formatPhone
+         * @throws Exception
+         *
+         * @param $phone
+         *
+         * @return mixed
+         */
+        private function _formatPhone($phone)
+        {
+            /**
+             * Namecheap API phone format requirement is +NNN.NNNNNNNNNN
+             */
+
+            // strip all non-digit characters
+            $phone = preg_replace('/[^\d]/', '', $phone);
+
+            // check country code
+            $phone_code = "";
+            foreach (self::$_phoneCountryCodes as $v) {
+                if (preg_match("/^$v\d+$/", $phone)) {
+                    $phone_code = $v;
+                    break;
+                }
+            }
+            if (!$phone_code) {
+                throw new Exception("Invalid phone number or phone country code: $phone");
+            }
+            // add '+' and dot to result phone number
+            $phone = preg_replace("/^$phone_code/", "+{$phone_code}.", $phone);
+            return $phone;
+        }
+
+
+        /**
+         * _getApiParams
+         * @param string $command
+         * @param array $params
+         * @return array
+         */
+        private function _getApiParams($command, array $params)
+        {
+
+            $params['Command'] = $command;
+            $params['ApiUser'] = $this->_apiUser;
+            $params['ApiKey']  = $this->_apiKey;
+
+            if (!array_key_exists('UserName', $params) || !strlen($params['UserName'])) {
+                $params['UserName'] = $params['ApiUser'];
+            }
+            if (!array_key_exists('ClientIp', $params)) {
+                $params['ClientIp'] = $this->_getClientIp();
+            }
+
+
+            // format phone/fax fields
+            foreach ($params as $k => &$v) {
+                if (preg_match('/(Phone|Fax)/i', $k)) {
+                    $v = trim($v);
+                    if(!empty($v)){
+                        $v = $this->_formatPhone($v);
+                    }
+                }
+            }
+
+            // force EPPCode to be base64 encoded
+            if (array_key_exists('EPPCode', $params)) {
+                $params['EPPCode'] = htmlspecialchars_decode($params['EPPCode'], ENT_QUOTES);
+                $params['EPPCode'] = "base64:" . base64_encode($params['EPPCode']);
+            }
+            return $params;
+        }
+
+
+        public function parseResultSyncHelper($item, $domainNameKey = "DomainName")
+        {
+            $result = array();
+            $attr = $item['@attributes'];
+            $result[strtolower($attr[$domainNameKey])] = $attr;
+            return $result;
+        }
+
+
+        /**
+         * _getApiUrl
+         * @param string $command
+         * @param array $params
+         * @return string
+         */
+        private function _getApiUrl($command, array $params)
+        {
+            return ($this->_testMode ? self::$testUrl : self::$url) . '?' . http_build_query($this->_getApiParams($command, $params),'','&');
+        }
+
+        /**
+         * _getClientIp
+         * @return string
+         */
+        private function _getClientIp()
+        {
+            $clientip = $_SERVER['REMOTE_ADDR'];
+            return $clientip ? $clientip : "10.11.12.13";
+        }
+
+        /**
+         * _xml2Array
+         * @throws NamecheapRegistrarApiException
+         *
+         * @param $xml
+         *
+         * @return array|string
+         */
+        private function _xml2Array($xml)
+        {
+            if (!($xml instanceof SimpleXMLElement)) {
+                throw new NamecheapRegistrarApiException("Not a SimpleXMLElement object");
+            }
+            $result = array();
+            foreach ($xml->attributes() as $attrName => $attr) {
+                $result['@attributes'][$attrName] = (string)$attr;
+            }
+            foreach ($xml->children() as $childName => $child) {
+                if (array_key_exists($childName, $result)) {
+                    if (!is_array($result[$childName]) || !isset($result[$childName][1])) {
+                        $result[$childName] = array($result[$childName]);
+                    }
+                    $result[$childName][] = $this->_xml2Array($child);
+                } else {
+                    $result[$childName] = $this->_xml2Array($child);
+                }
+            }
+            $value = trim((string)$xml);
+            if (array_keys($result)) {
+                if ($value) {
+                    $result['@value'] = $value;
+                }
             } else {
-                $result[$childName] = $this->_xml2Array($child);
+                $result = $value;
             }
+            return $result;
         }
-        $value = trim((string)$xml);
-        if (array_keys($result)) {
-            if ($value) {
-                $result['@value'] = $value;
-            }
-        } else {
-            $result = $value;
-        }
-        return $result;
     }
-}
 }
 
 /**
@@ -2780,7 +2701,7 @@ if (!class_exists('Net_IDNA2')) {
             // populate mbstring overloading cache if not set
             if (self::$_mb_string_overload === null) {
                 self::$_mb_string_overload = (extension_loaded('mbstring')
-                        && (ini_get('mbstring.func_overload') & 0x02) === 0x02);
+                    && (ini_get('mbstring.func_overload') & 0x02) === 0x02);
             }
         }
 
@@ -2798,8 +2719,10 @@ if (!class_exists('Net_IDNA2')) {
          *             on failures; false: loose mode, ideal for "wildlife" applications
          *             by silently ignoring errors and returning the original input instead]
          *
-         * @param mixed  $option Parameter to set (string: single parameter; array of Parameter => Value pairs)
-         * @param string $value  Value to use (if parameter 1 is a string)
+         * @throws InvalidArgumentException
+         *
+         * @param string|array  $option Parameter to set (string: single parameter; array of Parameter => Value pairs)
+         * @param boolean $value  Value to use (if parameter 1 is a string)
          *
          * @return boolean       true on success, false otherwise
          * @access public
@@ -2853,12 +2776,12 @@ if (!class_exists('Net_IDNA2')) {
          * Encode a given UTF-8 domain name.
          *
          * @param string $decoded           Domain name (UTF-8 or UCS-4)
-         * @param string $one_time_encoding Desired input encoding, see {@link set_parameter}
+         * @param boolean $one_time_encoding Desired input encoding, see {@link set_parameter}
          *                                  If not given will use default-encoding
          *
          * @return string Encoded Domain name (ACE string)
          * @return mixed  processed string
-         * @throws Exception
+         * @throws InvalidArgumentException
          * @access public
          */
         public function encode($decoded, $one_time_encoding = false) {
@@ -2942,10 +2865,10 @@ if (!class_exists('Net_IDNA2')) {
          * Decode a given ACE domain name.
          *
          * @param string $input             Domain name (ACE string)
-         * @param string $one_time_encoding Desired output encoding, see {@link set_parameter}
+         * @param bool $one_time_encoding Desired output encoding, see {@link set_parameter}
          *
-         * @return string                   Decoded Domain name (UTF-8 or UCS-4)
-         * @throws Exception
+         * @return array|string                   Decoded Domain name (UTF-8 or UCS-4)
+         * @throws InvalidArgumentException
          * @access public
          */
         public function decode($input, $one_time_encoding = false) {
@@ -3119,9 +3042,9 @@ if (!class_exists('Net_IDNA2')) {
                 $test = $decoded[$i];
                 // Will match [0-9a-zA-Z-]
                 if ((0x2F < $test && $test < 0x40)
-                        || (0x40 < $test && $test < 0x5B)
-                        || (0x60 < $test && $test <= 0x7B)
-                        || (0x2D == $test)
+                    || (0x40 < $test && $test < 0x5B)
+                    || (0x60 < $test && $test <= 0x7B)
+                    || (0x2D == $test)
                 ) {
                     $encoded .= chr($decoded[$i]);
                     $codecount++;
@@ -3166,8 +3089,8 @@ if (!class_exists('Net_IDNA2')) {
                     } else if ($decoded[$i] == $cur_code) {
                         for ($q = $delta, $k = $this->_base; 1; $k += $this->_base) {
                             $t = ($k <= $bias) ?
-                                    $this->_tmin :
-                                    (($k >= $bias + $this->_tmax) ? $this->_tmax : $k - $bias);
+                                $this->_tmin :
+                                (($k >= $bias + $this->_tmax) ? $this->_tmax : $k - $bias);
 
                             if ($q < $t) {
                                 break;
@@ -3240,8 +3163,8 @@ if (!class_exists('Net_IDNA2')) {
                     $idx += $digit * $w;
 
                     $t = ($k <= $bias) ?
-                            $this->_tmin :
-                            (($k >= $bias + $this->_tmax) ? $this->_tmax : ($k - $bias));
+                        $this->_tmin :
+                        (($k >= $bias + $this->_tmax) ? $this->_tmax : ($k - $bias));
 
                     if ($digit < $t) {
                         break;
@@ -3320,9 +3243,10 @@ if (!class_exists('Net_IDNA2')) {
          * @param array $input Unicode Characters
          *
          * @return string      Unicode Characters, Nameprep'd
-         * @throws Exception
+         * @throws Net_IDNA2_Exception_Nameprep
          * @access private
          */
+
         private function _nameprep($input) {
             $output = array();
 
@@ -3717,33 +3641,33 @@ if (!class_exists('Net_IDNA2')) {
                 } else if ($v < 1 << 11) {
                     // 2 bytes
                     $output .= chr(192 + ($v >> 6))
-                            . chr(128 + ($v & 63));
+                        . chr(128 + ($v & 63));
                 } else if ($v < 1 << 16) {
                     // 3 bytes
                     $output .= chr(224 + ($v >> 12))
-                            . chr(128 + (($v >> 6) & 63))
-                            . chr(128 + ($v & 63));
+                        . chr(128 + (($v >> 6) & 63))
+                        . chr(128 + ($v & 63));
                 } else if ($v < 1 << 21) {
                     // 4 bytes
                     $output .= chr(240 + ($v >> 18))
-                            . chr(128 + (($v >> 12) & 63))
-                            . chr(128 + (($v >> 6) & 63))
-                            . chr(128 + ($v & 63));
+                        . chr(128 + (($v >> 12) & 63))
+                        . chr(128 + (($v >> 6) & 63))
+                        . chr(128 + ($v & 63));
                 } else if ($v < 1 << 26) {
                     // 5 bytes
                     $output .= chr(248 + ($v >> 24))
-                            . chr(128 + (($v >> 18) & 63))
-                            . chr(128 + (($v >> 12) & 63))
-                            . chr(128 + (($v >> 6) & 63))
-                            . chr(128 + ($v & 63));
+                        . chr(128 + (($v >> 18) & 63))
+                        . chr(128 + (($v >> 12) & 63))
+                        . chr(128 + (($v >> 6) & 63))
+                        . chr(128 + ($v & 63));
                 } else if ($v < 1 << 31) {
                     // 6 bytes
                     $output .= chr(252 + ($v >> 30))
-                            . chr(128 + (($v >> 24) & 63))
-                            . chr(128 + (($v >> 18) & 63))
-                            . chr(128 + (($v >> 12) & 63))
-                            . chr(128 + (($v >> 6) & 63))
-                            . chr(128 + ($v & 63));
+                        . chr(128 + (($v >> 24) & 63))
+                        . chr(128 + (($v >> 18) & 63))
+                        . chr(128 + (($v >> 12) & 63))
+                        . chr(128 + (($v >> 6) & 63))
+                        . chr(128 + ($v & 63));
                 } else {
                     throw new UnexpectedValueException('Conversion from UCS-4 to UTF-8 failed: malformed input');
                 }
@@ -3915,4 +3839,3 @@ if (!class_exists('Net_IDNA2')) {
         // }}}
     }
 }
-


### PR DESCRIPTION
* - Removed debug mode - logModuleCall should always be used.
* - Removed transforming CA and US states as this is already done in WHMCS
* - Updated the phone number field used for domain registrations as WHMCS
formats this correctly already
* - Whenever logModuleCall is used in the main file, ensure that password is
passed to be obscured
* - Updated sync to search for the specific domain over listing all domains
* - Correct some docblocks in the namecheapapi file.
* - Add support for .uk domain extension

Added version bump to 1.2.9